### PR TITLE
Из вывода логирования убираем чувствительные данные

### DIFF
--- a/src/Iam.php
+++ b/src/Iam.php
@@ -123,7 +123,7 @@ class Iam implements IamTokenContract
 
             if (isset($token->iamToken))
             {
-                $this->logger()->info('YDB: Obtained new IAM token [' . $token->iamToken . '].');
+                $this->logger()->info('YDB: Obtained new IAM token [...' . substr($token->iamToken, -6) . '].');
                 $this->saveToken($token);
                 return $token->iamToken;
             }
@@ -315,7 +315,7 @@ class Iam implements IamTokenContract
             {
                 $this->iam_token = $token->iamToken;
                 $this->expires_at = $token->expiresAt;
-                $this->logger()->info('YDB: Reused IAM token [' . $this->iam_token . '].');
+                $this->logger()->info('YDB: Reused IAM token [...' . substr($this->iam_token, -6) . '].');
                 return $token->iamToken;
             }
         }

--- a/src/Session.php
+++ b/src/Session.php
@@ -161,7 +161,7 @@ class Session
 
         $result = $this->request('CreateSession');
         $session_id = $result->getSessionId();
-        $this->logger()->info('YDB: New session created [' . $session_id . '].');
+        $this->logger()->info('YDB: New session created [...' . substr($session_id, -6) . '].');
 
         $this->session_id = $session_id;
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -141,7 +141,7 @@ class Table
     {
         $result = $this->request('CreateSession');
         $session_id = $result->getSessionId();
-        $this->logger()->info('YDB: New session created [' . $session_id . '].');
+        $this->logger()->info('YDB: New session created [...' . substr($session_id, -6) . '].');
 
         $session = new Session($this, $session_id);
         static::$session_pool->addSession($session);


### PR DESCRIPTION
Писать чувствительные данные (например, как токен авторизации) в логи - это плохой тон. Логи имеют свойство оказываться доступными "наружу" в самом неожиданном месте, тем более в современных PHP-окружениях